### PR TITLE
Make data root be dynamically loaded, instead of hardcoding

### DIFF
--- a/configs/runtime.yaml
+++ b/configs/runtime.yaml
@@ -1,4 +1,5 @@
 runtime:
+  data_root: data/mnist
   batch_size: 64
   num_workers: 16
   train_val_split: 0.9

--- a/data/datasymlink
+++ b/data/datasymlink
@@ -1,1 +1,0 @@
-/home/sboulanger/data/

--- a/datasets/mnist.py
+++ b/datasets/mnist.py
@@ -4,7 +4,7 @@ from torchvision import datasets, transforms
 
 class MNIST(datasets.MNIST):
 
-    def __init__(self,root, image_size=28, transform=None, train=True, download=True):
+    def __init__(self, root, image_size=28, transform=None, train=True, download=True):
 
         self.image_size = image_size 
         self.train = train

--- a/systems/runtime.py
+++ b/systems/runtime.py
@@ -30,12 +30,15 @@ class Runtime(pl.LightningModule):
     ##########
 
     def prepare_data(self):
-        project_home = hydra.utils.get_original_cwd()
-        mnist_dataset = MNIST(root=project_home + "/data/datasymlink")
+        data_root = os.path.join(hydra.utils.get_original_cwd(), self.cfg.data_root)
+        os.makedirs(data_root, exist_ok=True)  # make in case does not exist
+        mnist_dataset = MNIST(root=data_root)
+
         train_samples_n = int(len(mnist_dataset) * self.cfg.train_val_split)
         val_samples_n   = len(mnist_dataset) - train_samples_n
-        self.training_dataset, self.validation_dataset = random_split(mnist_dataset,lengths=[train_samples_n, val_samples_n])
-        self.test_dataset= MNIST(root=project_home + "/data/datasymlink",train=False)
+
+        self.training_dataset, self.validation_dataset = random_split(mnist_dataset, lengths=[train_samples_n, val_samples_n])
+        self.test_dataset= MNIST(root=data_root, train=False)
 
     def train_dataloader(self):
         return DataLoader(self.training_dataset, batch_size=self.cfg.batch_size, num_workers=self.cfg.num_workers)


### PR DESCRIPTION
Currently, project root is hard coded to `https://github.com/kourai-labs/mnist/blob/734c01bd68f7db670aef1a3dcc10d58a50fc73df/systems/runtime.py#L34`

These changes instead add `data_root` as a config option to configs/runtime.yaml. I also remove the symlink folder, as I think it should be up to the user whether they're using a symlink or not. If the user wants to use a symlink, they can create one, then point the `data_root` config to that path.